### PR TITLE
Bump AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
```
> Task :app:mergeReleaseResources FAILED

> Task :app:processReleaseMainManifest

FAILURE: Build failed with an exception.

* What went wrong:

Execution failed for task ':app:mergeReleaseResources'.

> Multiple task action failures occurred:

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #6: Unexpected error during compile '/home/vagrant/build/net.xtlive.EDL.Dashboard/app/src/main/res/drawable/oil_temp.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #41: Unexpected error during compile '/home/vagrant/build/net.xtlive.EDL.Dashboard/app/src/main/res/mipmap-xxxhdpi/trip_reset.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.
...
```

ref: https://monitor.f-droid.org/builds/log/net.xtlive.EDL.Dashboard/7#site-footer

ref: https://issuetracker.google.com/issues/184872412 This is an issue of AGP 4.1. Updating AGP to 4.2 or above should fix it.

Fixed it for now directly in F-Droid: https://gitlab.com/fdroid/fdroiddata/-/commit/a983f24a87e5173ca284c71c14e4f93a8ca4622c